### PR TITLE
create tabs in a browserContext by default

### DIFF
--- a/__tests__/engine/connection.test.ts
+++ b/__tests__/engine/connection.test.ts
@@ -58,14 +58,14 @@ describe("target/connection tests", function() {
     test("it can create targets and connections", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         expect(connection).not.toBeNull();
     });
 
     test("it can load a page", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -80,7 +80,7 @@ describe("target/connection tests", function() {
     test("it can pass arguments to evaluate", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -95,7 +95,7 @@ describe("target/connection tests", function() {
     test("it can evaluate async expressions", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -114,7 +114,7 @@ describe("target/connection tests", function() {
     test("it should throw an error if evaluate throws an error", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -130,7 +130,7 @@ describe("target/connection tests", function() {
     test("it should throw an error if evaluateAsync returns a rejected promise", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -147,21 +147,10 @@ describe("target/connection tests", function() {
         await connection.release();
     });
 
-    test("it can manage targets", async function() {
-        const target = await headlessChrome.createTarget();
-        if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
-        if (!connection) throw new Error("jest_connection_not_created");
-        await connection.activate();
-        expect(await headlessChrome.getAvailableTarget()).toBeNull();
-        await connection.release();
-        expect(await headlessChrome.getAvailableTarget()).not.toBeNull();
-    });
-
     test("it should throw if evaluate is used on an inactive connection", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -177,7 +166,7 @@ describe("target/connection tests", function() {
     test("it should throw if an inactive connection is released", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         expect((async function() {
             await connection.release();
@@ -187,7 +176,7 @@ describe("target/connection tests", function() {
     test("it should throw if an already active connection is activated", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         expect((async function() {
@@ -196,40 +185,10 @@ describe("target/connection tests", function() {
         await connection.release();
     });
 
-    test("it should be able to collect dead targets", async function() {
-        const target = await headlessChrome.createTarget();
-        if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
-        if (!connection) throw new Error("jest_connection_not_created");
-        await connection.activate();
-        const target2 = await headlessChrome.createTarget();
-        if (!target2) throw new Error("no_target");
-        const connection2 = await createConnection(target2.tab, bridgePort);
-        if (!connection2) throw new Error("jest_connection_not_created");
-        await connection2.activate();
-        expect(headlessChrome.targets).toBeArrayOfSize(2);
-        await connection.release();
-        await headlessChrome.collectDeadTargets();
-        expect(headlessChrome.targets).toBeArrayOfSize(1);
-    });
-
-    test("it should throw if maxTargets is reached", async function() {
-        headlessChrome.maxTargets = 1;
-        const target = await headlessChrome.createTarget();
-        if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
-        if (!connection) throw new Error("jest_connection_not_created");
-        expect((async function() {
-            const target2 = await headlessChrome.createTarget();
-            if (!target2) throw new Error("no_target");
-            await createConnection(target2.tab, bridgePort);
-        })()).rejects.toThrowError("max_targets_reached");
-    });
-
     test("it can inject preloaders", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.injectPreloader({
             compiled: {
@@ -253,7 +212,7 @@ describe("target/connection tests", function() {
     test("it should throw if a preloader is injected into an active connection", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -274,7 +233,7 @@ describe("target/connection tests", function() {
     test("it can pipe console.log", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         connection.pipe.console(function(text) {
             expect(text).toBe("hi there!");
@@ -291,7 +250,7 @@ describe("target/connection tests", function() {
     test("it can pipe uncaughtException", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         connection.pipe.uncaughtException(function(exception) {
             expect(exception.text).toMatch("my test error");
@@ -313,7 +272,7 @@ describe("target/connection tests", function() {
     test("it should throw an error if an event is piped into an active connection", async function() {
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         expect((async function() {

--- a/__tests__/engine/launcher.test.ts
+++ b/__tests__/engine/launcher.test.ts
@@ -84,7 +84,7 @@ describe("launcher tests", function() {
         });
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         await connection.activate();
         await connection.client.Page.navigate({url: "https://expired.badssl.com/"});
         await connection.client.Page.loadEventFired();
@@ -106,7 +106,7 @@ describe("launcher tests", function() {
         });
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
         await connection.client.Page.loadEventFired();
@@ -129,7 +129,7 @@ describe("launcher tests", function() {
         });
         const target = await headlessChrome.createTarget();
         if (!target) throw new Error("no_target");
-        const connection = await createConnection(target.tab, bridgePort);
+        const connection = await createConnection(target, bridgePort);
         if (!connection) throw new Error("jest_connection_not_created");
         await connection.activate();
         await connection.client.Page.navigate({url: `http://localhost:${staticServerPort}`});
@@ -148,7 +148,7 @@ describe("launcher tests", function() {
         });
         const target2 = await headlessChrome.createTarget();
         if (!target2) throw new Error("no_target");
-        const connection2 = await createConnection(target2.tab, bridgePort);
+        const connection2 = await createConnection(target2, bridgePort);
         if (!connection2) throw new Error("jest_connection_not_created");
         await connection2.activate();
         await connection2.client.Page.navigate({url: `http://localhost:${staticServerPort}`});

--- a/__tests__/utils/getAyakashiInstance.ts
+++ b/__tests__/utils/getAyakashiInstance.ts
@@ -10,7 +10,7 @@ export async function getAyakashiInstance(
 ) {
     const target = await headlessChrome.createTarget();
     if (!target) throw new Error("no_target");
-    const connection = await createConnection(target.tab, bridgePort);
+    const connection = await createConnection(target, bridgePort);
     if (!connection) throw new Error("no_connection");
     const ayakashiInstance = await prelude(connection);
     const domqlPreloader = await compile(

--- a/src/engine/bridge.ts
+++ b/src/engine/bridge.ts
@@ -11,20 +11,11 @@ export function startBridge(browser: IHeadlessChrome, port: number): Promise<Ser
     const app = Express();
     app.use(bodyParser.json());
 
-    app.post("/get_available_target", async function(_req, res) {
-        const target = await browser.getAvailableTarget();
-        if (target) {
-            res.json({ok: true, tab: target.tab});
-        } else {
-            res.json({ok: false, msg: "no_available_target"});
-        }
-    });
-
     app.post("/create_target", async function(_req, res) {
         try {
             const target = await browser.createTarget();
             if (target) {
-                res.json({ok: true, tab: target.tab});
+                res.json({ok: true, target: target});
             } else {
                 res.json({ok: false, msg: "no_available_target"});
             }
@@ -33,34 +24,13 @@ export function startBridge(browser: IHeadlessChrome, port: number): Promise<Ser
         }
     });
 
-    app.post("/collect_dead_targets", async function(_req, res) {
+    app.post("/connection_released", async function(req, res) {
         try {
-            await browser.collectDeadTargets();
+            await browser.destroyTarget(req.body.targetId, req.body.browserContextId);
             res.json({ok: true});
         } catch (e) {
-            res.json({ok: false, msg: e.message});
-        }
-    });
-
-    app.post("/connection_activated", function(req, res) {
-        const target = browser.targets.find(trg => trg.tab.id === req.body.id);
-        if (target) {
-            target.active = true;
-            res.json({ok: true});
-        } else {
-            res.json({ok: false, msg: "invalid_target"});
-        }
-    });
-
-    app.post("/connection_released", function(req, res) {
-        const target = browser.targets.find(trg => trg.tab.id === req.body.id);
-        if (target) {
-            target.active = false;
-            target.locked = false;
-            target.lockedUntil = 0;
-            res.json({ok: true});
-        } else {
-            res.json({ok: false, msg: "invalid_target"});
+            d(e);
+            res.json({ok: false, msg: "could_not_destory_target"});
         }
     });
 

--- a/src/engine/browser.ts
+++ b/src/engine/browser.ts
@@ -1,11 +1,11 @@
+const CDP = require("chrome-remote-interface");
 import debug from "debug";
 import {launch, IBrowserInstance} from "./launcher";
 import {createTarget, Target} from "./createTarget";
-import {createConnection} from "../engine/createConnection";
 import {startBridge} from "./bridge";
 import {Server} from "http";
-import {forever} from "async";
 import {getOpLog} from "../opLog/opLog";
+import {ICDPClient} from "./createConnection";
 
 const d = debug("ayakashi:engine:browser");
 
@@ -14,9 +14,6 @@ const HOST = "localhost";
 export interface IHeadlessChrome {
     chromeInstance: IBrowserInstance | null;
     bridge: Server | null;
-    targets: Target[];
-    maxTargets: number;
-    getAvailableTarget: () => Promise<Target | null>;
     init: (options: {
         chromePath: string,
         headless?: boolean,
@@ -34,27 +31,21 @@ export interface IHeadlessChrome {
     }) => Promise<void>;
     close: () => Promise<void>;
     createTarget: () => Promise<Target | null>;
-    collectDeadTargets: () => Promise<void>;
+    destroyTarget: (targetId: string, browserContextId: string | null) => Promise<void>;
 }
-
-type TargetOpQueue = {exec: Function, cb: Function, op: string}[];
 
 const MAX_LAUNCH_ATTEMPTS = 3;
 
 export function getInstance(): IHeadlessChrome {
     const SIGINT = "SIGINT";
     let BRIDGE_PORT: number;
-    const targetOpQueue: TargetOpQueue = [];
-    const targetOpQueueSignal = {stop: false};
     let isHeadless = true;
     let isPersistentSession = false;
-    startTargetManager(targetOpQueueSignal, targetOpQueue);
+    let masterConnection: ICDPClient;
     const opLog = getOpLog();
     return {
         chromeInstance: null,
         bridge: null,
-        maxTargets: 10,
-        targets: [],
         init: async function(options) {
             if (this.chromeInstance) return;
             if (!options) throw new Error("init_options_not_set");
@@ -81,6 +72,7 @@ export function getInstance(): IHeadlessChrome {
             try {
                 BRIDGE_PORT = options.bridgePort;
                 this.bridge = await startBridge(this, BRIDGE_PORT);
+                masterConnection = await getMasterConnection(HOST, this.chromeInstance.port);
                 const sigintListener = async() => {
                     d("trap SIGINT, killing bridge and chrome");
                     await this.close();
@@ -96,18 +88,7 @@ export function getInstance(): IHeadlessChrome {
             let forceKill = false;
             try {
                 if (this.chromeInstance) {
-                    const target = await createTarget(
-                        HOST,
-                        this.chromeInstance.port,
-                        {
-                            isHeadless: isHeadless,
-                            isPersistentSession: isPersistentSession
-                        }
-                    );
-                    if (!target) throw new Error("cannot_kill_chrome_instance");
-                    const connection = await createConnection(target.tab, BRIDGE_PORT);
-                    if (!connection) throw new Error("cannot_kill_chrome_instance");
-                    await connection.client.Browser.close();
+                    await masterConnection.Browser.close();
                     this.chromeInstance = null;
                 }
             } catch (err) {
@@ -124,7 +105,6 @@ export function getInstance(): IHeadlessChrome {
                 opLog.error("Failed to close chrome");
             }
             return new Promise((resolve, reject) => {
-                targetOpQueueSignal.stop = true;
                 if (this.bridge) {
                     this.bridge.close()
                     .on("close", () => {
@@ -140,125 +120,34 @@ export function getInstance(): IHeadlessChrome {
                 }
             });
         },
-        /*
-            getAvailableTarget/createTarget mark the target as locked
-            with a lockedUntil of 10 seconds
-
-            when a connection is activated with connection.activate(), its target is marked
-            as active: true (in the bridge)
-
-            when a connection is released with connection.release(), its target is marked
-            as active: false and locked: false (in the bridge)
-
-            inactive and locked-expired targets are then collected with collectDeadTargets()
-        */
-        getAvailableTarget: function() {
-            const self = this;
-            return new Promise(function(resolve, reject) {
-                targetOpQueue.push({
-                    op: "getAvailableTarget",
-                    exec: function() {
-                        const target = self.targets.find(trg => !trg.active && !trg.locked);
-                        if (target) {
-                            target.locked = true;
-                            target.lockedUntil = Date.now() + 10000;
-                            return target;
-                        } else {
-                            return null;
-                        }
-                    },
-                    cb: function(err?: Error | null, result?: Target | null) {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
-                    }
-                });
-            });
-        },
         createTarget: async function() {
-            const self = this;
-            return new Promise(function(resolve, reject) {
-                targetOpQueue.push({
-                    op: "createTarget",
-                    exec: async function() {
-                        if (self.targets.length >= self.maxTargets) {
-                            throw new Error("max_targets_reached");
-                        }
-                        if (self.chromeInstance) {
-                            try {
-                                const target = await createTarget(
-                                    HOST,
-                                    self.chromeInstance.port,
-                                    {
-                                        isHeadless: isHeadless,
-                                        isPersistentSession: isPersistentSession
-                                    }
-                                );
-                                target.locked = true;
-                                target.lockedUntil = Date.now() + 10000;
-                                self.targets.push(target);
-                                return target;
-                            } catch (err) {
-                                d(err);
-                                throw new Error("could_not_create_target");
-                            }
-                        } else {
-                            return null;
-                        }
-                    },
-                    cb: function(err?: Error | null, result?: Target | null) {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(result);
-                        }
-                    }
-                });
-            });
+            if (this.chromeInstance) {
+                try {
+                    return createTarget(
+                        HOST,
+                        this.chromeInstance.port,
+                        masterConnection,
+                        isHeadless && !isPersistentSession
+                    );
+                } catch (err) {
+                    d(err);
+                    throw new Error("could_not_create_target");
+                }
+            } else {
+                return null;
+            }
         },
-        collectDeadTargets: async function() {
-            const self = this;
-            return new Promise(function(resolve, reject) {
-                targetOpQueue.push({
-                    op: "collectDeadTargets",
-                    exec: async function() {
-                        d("collecting dead targets");
-                        try {
-                            //close inactive targets
-                            //inactive = target.active == false or target.locked with an expired lock
-                            const inactiveTargets = self.targets
-                            .filter(trg => !trg.active || (trg.locked && trg.lockedUntil < Date.now()))
-                            .map(trg => {
-                                trg.active = false;
-                                return trg;
-                            });
-                            //close them
-                            await Promise.all(
-                                inactiveTargets
-                                .map(trg => trg.close())
-                            );
-                            //remove them from the instance
-                            const deadTargetsIndexes = self.targets
-                            .map((trg, i) => trg.active === false ? i : -1)
-                            .filter(i => i > -1);
-                            deadTargetsIndexes.forEach(index => {
-                                self.targets.splice(index, 1);
-                            });
-                        } catch (err) {
-                            d(err);
-                            throw new Error("could_not_collect_targets");
-                        }
-                    },
-                    cb: function(err?: Error | null) {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    }
+        destroyTarget: async function(targetId, browserContextId) {
+            if (!this.chromeInstance) return;
+            if (browserContextId) {
+                d("disposing browserContextId", browserContextId);
+                await masterConnection.Target.disposeBrowserContext({
+                    browserContextId: browserContextId
                 });
+            }
+            d("closing target", targetId);
+            await masterConnection.Target.closeTarget({
+                targetId: targetId
             });
         }
     };
@@ -329,25 +218,9 @@ function sleep(delay: number) {
     return new Promise(resolve => setTimeout(resolve, delay));
 }
 
-function startTargetManager(signal: {stop: boolean}, targetOpQueue: TargetOpQueue) {
-    forever(async function(next) {
-        if (signal.stop) return next(new Error("stop"));
-        if (targetOpQueue.length > 0) {
-            const op = targetOpQueue.shift();
-            if (op) {
-                d("targetOpQueue:", op.op);
-                try {
-                    const result = await op.exec();
-                    op.cb(null, result);
-                } catch (err) {
-                    op.cb(err);
-                }
-                setTimeout(next, 50);
-            } else {
-                setTimeout(next, 50);
-            }
-        } else {
-            setTimeout(next, 50);
-        }
-    }, function() {});
+async function getMasterConnection(host: string, port: number): Promise<ICDPClient> {
+    const {webSocketDebuggerUrl} = await CDP.Version({host, port});
+    return CDP({
+        target: webSocketDebuggerUrl || `ws://${host}:${port}/devtools/browser`
+    });
 }

--- a/src/engine/createConnection.ts
+++ b/src/engine/createConnection.ts
@@ -1,6 +1,6 @@
 const CDP = require("chrome-remote-interface");
 import debug from "debug";
-import {Unsubscriber, Target} from "./createTarget";
+import {Target} from "./createTarget";
 import {isRegExp} from "util";
 //@ts-ignore
 import {Mouse, Keyboard, Touchscreen} from "@ayakashi/input";
@@ -9,6 +9,8 @@ import {ExponentialStrategy} from "backoff";
 import request from "request-promise-native";
 
 const d = debug("ayakashi:engine:connection");
+
+type Unsubscriber = () => void;
 
 /**
  * Emulation options for the scrapper to use.

--- a/src/engine/createTarget.ts
+++ b/src/engine/createTarget.ts
@@ -1,61 +1,43 @@
-const CDP = require("chrome-remote-interface");
 import debug from "debug";
+import {ICDPClient} from "./createConnection";
 export type Unsubscriber = () => void;
 
 const d = debug("ayakashi:engine:target");
 
 export type Target = {
-    tab: ICDPTab | string;
-    active: boolean;
-    locked: boolean;
-    lockedUntil: number;
-    close: () => Promise<void>;
-};
-
-export interface ICDPTab {
-    description: string;
-    devtoolsFrontendUrl: string;
-    id: string;
-    title: string;
-    type: string;
-    url: string;
+    targetId: string;
     webSocketDebuggerUrl: string;
-}
+    browserContextId: string | null;
+};
 
 export async function createTarget(
     host: string,
     port: number,
-    options: {
-        isHeadless: boolean,
-        isPersistentSession: boolean
-    }
+    masterConnection: ICDPClient,
+    inNewContext: boolean
 ): Promise<Target> {
     d(`creating new target tab for host:${host} port:${port}`);
-    if (!options.isHeadless || options.isPersistentSession) {
-        const tab: ICDPTab = await CDP.New({host: host, port: port});
-        return {
-            tab: tab,
-            active: false,
-            locked: false,
-            lockedUntil: 0,
-            close: () => CDP.Close({host: host, port: port, id: tab.id})
-        };
-    } else {
-        const {webSocketDebuggerUrl} = await CDP.Version({host, port});
-        const browser = await CDP({
-            target: webSocketDebuggerUrl || `ws://${host}:${port}/devtools/browser`
-        });
-        const {browserContextId} = await browser.Target.createBrowserContext();
-        const {targetId} = await browser.Target.createTarget({
+    if (inNewContext) {
+        const {browserContextId} = await masterConnection.Target.createBrowserContext();
+        const {targetId} = await masterConnection.Target.createTarget({
             url: "about:blank",
             browserContextId
         });
+        d("target created:", targetId, "in context:", browserContextId);
         return {
-            tab: `ws://${host}:${port}/devtools/page/${targetId}`,
-            active: false,
-            locked: false,
-            lockedUntil: 0,
-            close: () => CDP.Close({host: host, port: port, id: targetId})
+            targetId: targetId,
+            webSocketDebuggerUrl: `ws://${host}:${port}/devtools/page/${targetId}`,
+            browserContextId: browserContextId
+        };
+    } else {
+        const {targetId} = await masterConnection.Target.createTarget({
+            url: "about:blank"
+        });
+        d("target created:", targetId);
+        return {
+            targetId: targetId,
+            webSocketDebuggerUrl: `ws://${host}:${port}/devtools/page/${targetId}`,
+            browserContextId: null
         };
     }
 }

--- a/src/engine/createTarget.ts
+++ b/src/engine/createTarget.ts
@@ -1,6 +1,5 @@
 import debug from "debug";
 import {ICDPClient} from "./createConnection";
-export type Unsubscriber = () => void;
 
 const d = debug("ayakashi:engine:target");
 

--- a/src/prelude/prelude.ts
+++ b/src/prelude/prelude.ts
@@ -198,6 +198,11 @@ for (const link of extractedLinks) {
 */
     yieldEach: (extracted: object[] | Promise<object[]>) => Promise<void>;
 /**
+ * Recursively re-run the scrapper by yielding the extracted data to itself.
+ * The data will be available in the input object.
+*/
+    recursiveYield: (extracted: object | Promise<object>) => Promise<void>;
+/**
  * Retry an async operation.
  * Default is 10 retries.
  * If the operation returns a result, that result will also be returned by retry.

--- a/src/runner/parseConfig.ts
+++ b/src/runner/parseConfig.ts
@@ -568,6 +568,7 @@ function addPreStep(
                             operationId: "${options.operationId}",
                             startDate: "${options.startDate}",
                             procName: "proc_from_pre_${step}_to_${step}",
+                            selfTopic: "${previousStep}",
                             appRoot: "${appRoot}"
                         });
                     } else {
@@ -581,6 +582,7 @@ function addPreStep(
                             operationId: "${options.operationId}",
                             startDate: "${options.startDate}",
                             procName: "proc_from_pre_${step}_to_${step}",
+                            selfTopic: "${previousStep}",
                             appRoot: "${appRoot}"
                         });
                     }
@@ -630,6 +632,7 @@ function addParallelPreStep(
                                 operationId: "${options.operationId}",
                                 startDate: "${options.startDate}",
                                 procName: "proc_from_pre_${step}_to_${step}",
+                                selfTopic: "${ppst}",
                                 appRoot: "${appRoot}"
                             });
                         } else {
@@ -643,6 +646,7 @@ function addParallelPreStep(
                                 operationId: "${options.operationId}",
                                 startDate: "${options.startDate}",
                                 procName: "proc_from_pre_${step}_to_${step}",
+                                selfTopic: "${ppst}",
                                 appRoot: "${appRoot}"
                             });
                         }
@@ -675,6 +679,7 @@ function addParallelPreStep(
                             operationId: "${options.operationId}",
                             startDate: "${options.startDate}",
                             procName: "proc_from_pre_${step}_to_${step}",
+                            selfTopic: "${previousPreviousStep}",
                             appRoot: "${appRoot}"
                         });
                     } else {
@@ -688,6 +693,7 @@ function addParallelPreStep(
                             operationId: "${options.operationId}",
                             startDate: "${options.startDate}",
                             procName: "proc_from_pre_${step}_to_${step}",
+                            selfTopic: "${previousPreviousStep}",
                             appRoot: "${appRoot}"
                         });
                     }

--- a/src/runner/scrapperWrapper.ts
+++ b/src/runner/scrapperWrapper.ts
@@ -44,6 +44,7 @@ type PassedLog = {
             protocolPort: number
         },
         saveTopic: string,
+        selfTopic: string,
         projectFolder: string,
         storeProjectFolder: string,
         operationId: string,
@@ -143,6 +144,22 @@ export default async function scrapperWrapper(log: PassedLog) {
                 await Promise.all(extracted.map(ex => {
                     return ayakashiInstance.yield(ex);
                 }));
+            }
+        };
+        ayakashiInstance.recursiveYield = async function(extracted) {
+            if (extracted instanceof Promise) {
+                const actualExtracted = await extracted;
+                if (!actualExtracted || typeof actualExtracted !== "object") return;
+                await pipeprocClient.commit({
+                    topic: log.body.selfTopic,
+                    body: actualExtracted
+                });
+            } else {
+                if (!extracted || typeof extracted !== "object") return;
+                await pipeprocClient.commit({
+                    topic: log.body.selfTopic,
+                    body: extracted
+                });
             }
         };
 

--- a/src/runner/scrapperWrapper.ts
+++ b/src/runner/scrapperWrapper.ts
@@ -1,6 +1,6 @@
 import request from "request-promise-native";
 import {createConnection, EmulatorOptions, IConnection} from "../engine/createConnection";
-import {ICDPTab} from "../engine/createTarget";
+import {Target} from "../engine/createTarget";
 import {prelude, IAyakashiInstance} from "../prelude/prelude";
 //@ts-ignore
 import requireAll from "require-all";
@@ -249,60 +249,19 @@ export default async function scrapperWrapper(log: PassedLog) {
     }
 }
 
-async function getTarget(port: number): Promise<ICDPTab | null> {
-    let tab;
-    tab = await getAvailableTarget(port);
-    if (tab) {
-        return tab;
-    } else {
-        tab = await createTarget(port);
-    }
-    if (tab) {
-        return tab;
-    } else {
-        await collectDeadTargets(port);
-        tab = await createTarget(port);
-    }
-    if (tab) {
-        return tab;
-    } else {
-        return null;
-    }
-}
-
-async function getAvailableTarget(port: number): Promise<ICDPTab | null> {
-    const resp = await request.post(`http://localhost:${port}/get_available_target`);
-    d("bridge response:", resp);
-    if (resp) {
-        const parsedResp = JSON.parse(resp);
-        if (parsedResp.ok) {
-            return parsedResp.tab;
-        } else {
-            return null;
-        }
-    } else {
-        return null;
-    }
-}
-
-async function createTarget(port: number): Promise<ICDPTab | null> {
+async function getTarget(port: number): Promise<Target | null> {
     const resp = await request.post(`http://localhost:${port}/create_target`);
     d("bridge response:", resp);
     if (resp) {
         const parsedResp = JSON.parse(resp);
         if (parsedResp.ok) {
-            return parsedResp.tab;
+            return parsedResp.target;
         } else {
             return null;
         }
     } else {
         return null;
     }
-}
-
-async function collectDeadTargets(port: number): Promise<void> {
-    const resp = request.post(`http://localhost:${port}/collect_dead_targets`);
-    d("bridge response:", resp);
 }
 
 async function loadPreloaders(


### PR DESCRIPTION
Each scrapper invocation will now run in its own browserContext.
BrowserContexts are like an incognito profile but you can have more than one.
BrowserContext can be disabled by using a persistent session or by running chrome in non-headless mode.