### PR TITLE
Typo fix

### DIFF
--- a/__tests__/runner/parseConfig/createProcGenerators.test.ts
+++ b/__tests__/runner/parseConfig/createProcGenerators.test.ts
@@ -8,7 +8,7 @@ describe("createProcGenerators", function() {
     test("really simple waterfall", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -42,10 +42,10 @@ describe("createProcGenerators", function() {
     test("simple waterfall", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -85,7 +85,7 @@ describe("createProcGenerators", function() {
     test("really simple parallel", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -119,10 +119,10 @@ describe("createProcGenerators", function() {
     test("simple parallel", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -165,17 +165,17 @@ describe("createProcGenerators", function() {
     test("waterfall with nested parallel", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -227,23 +227,23 @@ describe("createProcGenerators", function() {
     test("waterfall with nested parallel 2", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -309,17 +309,17 @@ describe("createProcGenerators", function() {
     test("parallel with nested waterfall", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -374,23 +374,23 @@ describe("createProcGenerators", function() {
     test("parallel with nested waterfall 2", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -458,7 +458,7 @@ describe("createProcGenerators", function() {
     test("retries are passed on correctly", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 config: {
                     retries: 10
@@ -499,10 +499,10 @@ describe("createProcGenerators", function() {
     test("selfTopic is correct, parallel", async function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -531,23 +531,23 @@ describe("createProcGenerators", function() {
     test("selfTopic is correct, parallel with nested waterfall", async function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -584,10 +584,10 @@ describe("createProcGenerators", function() {
     test("selfTopic is correct, waterfall", async function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -616,23 +616,23 @@ describe("createProcGenerators", function() {
     test("selfTopic is correct, waterfall with nested parallel", async function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]

--- a/__tests__/runner/parseConfig/firstPass.test.ts
+++ b/__tests__/runner/parseConfig/firstPass.test.ts
@@ -7,7 +7,7 @@ describe("firstPass", function() {
     test("it parses configs with a single step correctly, waterfall", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -18,7 +18,7 @@ describe("firstPass", function() {
     test("it parses configs with a single step correctly, parallel", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -29,10 +29,10 @@ describe("firstPass", function() {
     test("it parses configs with multiple steps correctly, waterfall", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -44,10 +44,10 @@ describe("firstPass", function() {
     test("it parses configs with multiple steps correctly, parallel", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }]
         };
@@ -59,16 +59,16 @@ describe("firstPass", function() {
     test("it parses configs with nested steps correctly, waterfall-parallel", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -84,16 +84,16 @@ describe("firstPass", function() {
     test("it parses configs with nested steps correctly, parallel-waterfall", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -148,30 +148,30 @@ describe("firstPass", function() {
     test("it parses configs with multi-nested levels, parallel", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 //@ts-ignore
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     //@ts-ignore
                     parallel: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test",
                         parallel: [{
-                            type: "scrapper",
+                            type: "scraper",
                             module: "test",
                             waterfall: [{
-                                type: "scrapper",
+                                type: "scraper",
                                 module: "test"
                             }, {
-                                type: "scrapper",
+                                type: "scraper",
                                 module: "test"
                             }]
                         }]
@@ -192,30 +192,30 @@ describe("firstPass", function() {
     test("it parses configs with multi-nested levels, waterfall", function() {
         const config: Config = {
             waterfall: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 //@ts-ignore
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     //@ts-ignore
                     waterfall: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test",
                         waterfall: [{
-                            type: "scrapper",
+                            type: "scraper",
                             module: "test",
                             parallel: [{
-                                type: "scrapper",
+                                type: "scraper",
                                 module: "test"
                             }, {
-                                type: "scrapper",
+                                type: "scraper",
                                 module: "test"
                             }]
                         }]

--- a/__tests__/runner/parseConfig/stepValidation.test.ts
+++ b/__tests__/runner/parseConfig/stepValidation.test.ts
@@ -7,21 +7,21 @@ describe("validation", function() {
     test("it doesn't allow configs nested more than 2 levels deep", function() {
         const config: Config = {
             parallel: [{
-                type: "scrapper",
+                type: "scraper",
                 module: "test"
             }, {
-                type: "scrapper",
+                type: "scraper",
                 module: "test",
                 //@ts-ignore
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }, {
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     //@ts-ignore
                     parallel: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test"
                     }]
                 }]
@@ -55,7 +55,7 @@ describe("validation", function() {
             parallel: [{
                 //@ts-ignore
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -69,10 +69,10 @@ describe("validation", function() {
             parallel: [{
                 //@ts-ignore
                 parallel: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     parallel: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test"
                     }]
                 }]
@@ -87,7 +87,7 @@ describe("validation", function() {
             waterfall: [{
                 //@ts-ignore
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test"
                 }]
             }]
@@ -101,10 +101,10 @@ describe("validation", function() {
             waterfall: [{
                 //@ts-ignore
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     waterfall: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test"
                     }]
                 }]
@@ -120,10 +120,10 @@ describe("validation", function() {
             somethingElse: [{
                 //@ts-ignore
                 waterfall: [{
-                    type: "scrapper",
+                    type: "scraper",
                     module: "test",
                     waterfall: [{
-                        type: "scrapper",
+                        type: "scraper",
                         module: "test"
                     }]
                 }]

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "clean": "tsc --build --clean",
     "build": "tsc --build --clean && tsc --build",
     "watch": "tsc --build --clean && tsc --watch",
-    "test": "npm run build && node lib/cli/cli.js get-chrome ./__tests__ && jest --forceExit",
+    "test": "npm run build && node lib/cli/cli.js get-chrome ./__tests__ && node scripts/checkTypo.js && jest --forceExit",
     "build-types": "rm -rf ./lib && tsc --build --clean && tsc -d --emitDeclarationOnly --allowJs false && node scripts/formatTypes.js",
     "generate-core-action-docs": "typedoc --mode file --json ./doc.json && node ./scripts/generateCoreActionDocs.js && rm ./doc.json",
     "postinstall": "node scripts/postInstall.js",

--- a/scripts/checkTypo.js
+++ b/scripts/checkTypo.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const path = require("path");
+
+const flatten = arr => arr.reduce((acc, val) =>
+    acc.concat(Array.isArray(val) ? flatten(val) : val), []);
+
+//eslint-disable-next-line
+Array.prototype.flatten = function() {
+    return flatten(this);
+};
+
+function walk(dir) {
+    return fs.readdirSync(dir)
+        .map(file => fs.statSync(path.join(dir, file)).isDirectory()
+            ? walk(path.join(dir, file))
+            : path.join(dir, file).replace(/\\/g, "/")).flatten();
+}
+
+const files = walk("./src").concat(walk("./__tests__"));
+
+let typoCount = 0;
+const filesWithTypo = [];
+
+files.forEach(function(file) {
+    const content = fs.readFileSync(file, "utf8");
+    if (content.match(/scrapper/gi)) {
+        typoCount += (content.match(/scrapper/gi) || []).length;
+        filesWithTypo.push(file);
+    }
+});
+
+//there are already 11 typos on the deprecation warnings
+if (typoCount > 11) {
+    console.error(`${typoCount - 11} typo(s) found on these files:`);
+    console.error(filesWithTypo);
+    process.exit(1);
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,9 +14,9 @@ import {generateProp} from "./scaffold/generateProp";
 import {generateAction} from "./scaffold/generateAction";
 import {generateExtractor} from "./scaffold/generateExtractor";
 import {generatePreloader} from "./scaffold/generatePreloader";
-import {generateScrapper} from "./scaffold/generateScrapper";
-import {generateRenderlessScrapper} from "./scaffold/generateRenderlessScrapper";
-import {generateApiScrapper} from "./scaffold/generateApiScrapper";
+import {generateScraper} from "./scaffold/generateScraper";
+import {generateRenderlessScraper} from "./scaffold/generateRenderlessScraper";
+import {generateApiScraper} from "./scaffold/generateApiScraper";
 import {generateScript} from "./scaffold/generateScript";
 import {generateProject} from "./scaffold/generateProject";
 import {showBoxUpdate, showLineUpdate} from "./update/showUpdate";
@@ -27,7 +27,7 @@ yargs
     .command("run [dir]", "Runs a project", (_argv) => {
         yargs
             .positional("dir", {
-                describe: "The root directory of a project or a scrapper file when --simple mode is used",
+                describe: "The root directory of a project or a scraper file when --simple mode is used",
                 default: "."
             })
             .option("configFile", {
@@ -41,7 +41,7 @@ yargs
             })
             .option("simple", {
                 type: "boolean",
-                describe: "Run a single scrapper"
+                describe: "Run a single scraper"
             })
             .option("resume", {
                 type: "boolean",
@@ -60,7 +60,7 @@ yargs
         const resume = <boolean>argv.resume || false;
         let directory: string;
         let config: Config;
-        let simpleScrapper = "";
+        let simpleScraper = "";
         if (argv.jsonConfig) {
             const fromJson = prepareFromJson(<string>argv.dir, <string>argv.jsonConfig);
             config = fromJson.config;
@@ -70,14 +70,14 @@ yargs
                 const simple = prepareSimple(<string>argv.dir, <string>argv.out);
                 config = simple.config;
                 directory = simple.directory;
-                simpleScrapper = simple.scrapper;
+                simpleScraper = simple.scraper;
             } else {
                 const standard = prepareStandard(<string>argv.dir, <string>argv.configFile);
                 config = standard.config;
                 directory = standard.directory;
             }
         }
-        run(directory, config, resume, simpleScrapper).then(async function() {
+        run(directory, config, resume, simpleScraper).then(async function() {
             opLog.info("Nothing more to do!");
             await showBoxUpdate();
         }).catch(function(err) {
@@ -96,17 +96,17 @@ yargs
                 type: "boolean",
                 describe: "Generate a new project"
             })
-            .option("scrapper", {
+            .option("scraper", {
                 type: "boolean",
-                describe: "Generate a new scrapper"
+                describe: "Generate a new scraper"
             })
-            .option("renderlessScrapper", {
+            .option("renderlessScraper", {
                 type: "boolean",
-                describe: "Generate a new renderlessScrapper"
+                describe: "Generate a new renderlessScraper"
             })
-            .option("apiScrapper", {
+            .option("apiScraper", {
                 type: "boolean",
-                describe: "Generate a new apiScrapper"
+                describe: "Generate a new apiScraper"
             })
             .option("script", {
                 type: "boolean",
@@ -130,7 +130,7 @@ yargs
             })
             .option("name", {
                 type: "string",
-                describe: "The name of the new scrapper|renderlessScrapper|script|prop|action|extractor|preloader"
+                describe: "The name of the new scraper|renderlessScraper|script|prop|action|extractor|preloader"
             })
             .epilogue("Learn more at https://ayakashi.io/docs/reference/cli-commands.html#new");
         //@ts-ignore
@@ -138,8 +138,8 @@ yargs
         //tslint:disable cyclomatic-complexity
         const opLog = getOpLog();
         if ((!argv.prop && !argv.project && !argv.action && !argv.extractor &&
-            !argv.preloader && !argv.scrapper && !argv.renderlessScrapper &&
-            !argv.apiScrapper && !argv.script) || argv.project) {
+            !argv.preloader && !argv.scraper && !argv.renderlessScraper &&
+            !argv.apiScraper && !argv.script) || argv.project) {
             if (argv.dir === ".") {
                 await generateProject(getDirectory(argv.dir), true);
             } else {
@@ -173,27 +173,27 @@ yargs
                 process.exit(1);
             }
             await generatePreloader(getDirectory(argv.dir), name);
-        } else if (argv.scrapper) {
-            const name = await getName(argv.name, "scrapper");
+        } else if (argv.scraper) {
+            const name = await getName(argv.name, "scraper");
             if (!name) {
-                opLog.error("Invalid scrapper name");
+                opLog.error("Invalid scraper name");
                 process.exit(1);
             }
-            await generateScrapper(getDirectory(argv.dir), name);
-        } else if (argv.renderlessScrapper) {
-            const name = await getName(argv.name, "renderlessScrapper");
+            await generateScraper(getDirectory(argv.dir), name);
+        } else if (argv.renderlessScraper) {
+            const name = await getName(argv.name, "renderlessScraper");
             if (!name) {
-                opLog.error("Invalid renderlessScrapper name");
+                opLog.error("Invalid renderlessScraper name");
                 process.exit(1);
             }
-            await generateRenderlessScrapper(getDirectory(argv.dir), name);
-        } else if (argv.apiScrapper) {
-            const name = await getName(argv.name, "apiScrapper");
+            await generateRenderlessScraper(getDirectory(argv.dir), name);
+        } else if (argv.apiScraper) {
+            const name = await getName(argv.name, "apiScraper");
             if (!name) {
-                opLog.error("Invalid apiScrapper name");
+                opLog.error("Invalid apiScraper name");
                 process.exit(1);
             }
-            await generateApiScrapper(getDirectory(argv.dir), name);
+            await generateApiScraper(getDirectory(argv.dir), name);
         }  else if (argv.script) {
             const name = await getName(argv.name, "script");
             if (!name) {

--- a/src/cli/prepareSimple.ts
+++ b/src/cli/prepareSimple.ts
@@ -3,19 +3,19 @@ import {getDirectory} from "./getDirectory";
 import {sep} from "path";
 import {Config} from "../runner/parseConfig";
 
-export function prepareSimple(file: string, out: string): {config: Config, directory: string, scrapper: string} {
+export function prepareSimple(file: string, out: string): {config: Config, directory: string, scraper: string} {
     const opLog = getOpLog();
     if (file === ".") {
-        opLog.error("Simple mode requires a scrapper file as input");
+        opLog.error("Simple mode requires a scraper file as input");
         return process.exit(1);
     }
     const splittedDir = file.split(sep);
-    const scrapper = splittedDir.pop();
+    const scraper = splittedDir.pop();
     const directory = getDirectory(splittedDir.join("/"));
     process.chdir(directory);
-    opLog.info("running scrapper in simple mode");
+    opLog.info("running scraper in simple mode");
     opLog.info("directory:", directory);
-    opLog.info("scrapper:", <string>scrapper);
+    opLog.info("scraper:", <string>scraper);
     let saveFile: string;
     let saveScript: string;
     if (out === "sqlite") {
@@ -38,8 +38,8 @@ export function prepareSimple(file: string, out: string): {config: Config, direc
     return {
         config: {
             waterfall: [{
-                type: "scrapper",
-                module: <string>scrapper,
+                type: "scraper",
+                module: <string>scraper,
                 config: {
                     localAutoLoad: false,
                     simple: true
@@ -54,6 +54,6 @@ export function prepareSimple(file: string, out: string): {config: Config, direc
             }]
         },
         directory: directory,
-        scrapper: <string>scrapper
+        scraper: <string>scraper
     };
 }

--- a/src/cli/scaffold/generateApiScraper.ts
+++ b/src/cli/scaffold/generateApiScraper.ts
@@ -11,7 +11,7 @@ const mkdirp = promisify(_mkdirp);
 const writeFile = promisify(_writeFile);
 const exists = promisify(_exists);
 
-export async function generateApiScrapper(directory: string, name: string) {
+export async function generateApiScraper(directory: string, name: string) {
     const opLog = getOpLog();
     let fileName: string;
     if (name.indexOf(".js") > -1) {
@@ -19,14 +19,14 @@ export async function generateApiScrapper(directory: string, name: string) {
     } else {
         fileName = `${name}.js`;
     }
-    const scrappersFolder = pathJoin(directory, "scrappers");
-    const filePath = pathJoin(scrappersFolder, fileName);
+    const scrapersFolder = pathJoin(directory, "scrapers");
+    const filePath = pathJoin(scrapersFolder, fileName);
     if (await exists(filePath)) {
-        opLog.error(`scrapper <${name}> already exists in ${filePath}`);
+        opLog.error(`scraper <${name}> already exists in ${filePath}`);
         return;
     }
     opLog.info(`Created <${name}> in ${filePath}`);
-    await mkdirp(scrappersFolder);
+    await mkdirp(scrapersFolder);
     const content = getContent();
     await writeFile(filePath, content);
 }

--- a/src/cli/scaffold/generateProject.ts
+++ b/src/cli/scaffold/generateProject.ts
@@ -7,7 +7,7 @@ import {
 import {exec} from "child_process";
 import {getOpLog} from "../../opLog/opLog";
 
-import {generateScrapper} from "./generateScrapper";
+import {generateScraper} from "./generateScraper";
 import {generateScript} from "./generateScript";
 
 const mkdirp = promisify(_mkdirp);
@@ -32,7 +32,7 @@ export async function generateProject(projectDir: string, useCurrentFolder: bool
     await writeFile("ayakashi.config.js", getConfig());
     opLog.info("generating package.json");
     await writeFile("package.json", getpackageJson());
-    await generateScrapper(projectDir, "githubAbout");
+    await generateScraper(projectDir, "githubAbout");
     await generateScript(projectDir, "getPage");
     await writeFile(".gitignore", getGitIgnore());
     let npm = "npm";
@@ -62,7 +62,7 @@ module.exports = {
         type: "script",
         module: "getPage"
     }, {
-        type: "scrapper",
+        type: "scraper",
         module: "githubAbout"
     }, {
         type: "script",

--- a/src/cli/scaffold/generateRenderlessScraper.ts
+++ b/src/cli/scaffold/generateRenderlessScraper.ts
@@ -11,7 +11,7 @@ const mkdirp = promisify(_mkdirp);
 const writeFile = promisify(_writeFile);
 const exists = promisify(_exists);
 
-export async function generateScrapper(directory: string, name: string) {
+export async function generateRenderlessScraper(directory: string, name: string) {
     const opLog = getOpLog();
     let fileName: string;
     if (name.indexOf(".js") > -1) {
@@ -19,14 +19,14 @@ export async function generateScrapper(directory: string, name: string) {
     } else {
         fileName = `${name}.js`;
     }
-    const scrappersFolder = pathJoin(directory, "scrappers");
-    const filePath = pathJoin(scrappersFolder, fileName);
+    const scrapersFolder = pathJoin(directory, "scrapers");
+    const filePath = pathJoin(scrapersFolder, fileName);
     if (await exists(filePath)) {
-        opLog.error(`scrapper <${name}> already exists in ${filePath}`);
+        opLog.error(`scraper <${name}> already exists in ${filePath}`);
         return;
     }
     opLog.info(`Created <${name}> in ${filePath}`);
-    await mkdirp(scrappersFolder);
+    await mkdirp(scrapersFolder);
     const content = getContent();
     await writeFile(filePath, content);
 }
@@ -34,10 +34,10 @@ export async function generateScrapper(directory: string, name: string) {
 function getContent() {
     return (
 `/**
-* @param {import("@ayakashi/types").IAyakashiInstance} ayakashi
+* @param {import("@ayakashi/types").IRenderlessAyakashiInstance} ayakashi
 */
 module.exports = async function(ayakashi, input, params) {
-    await ayakashi.goTo(input.page);
+    await ayakashi.load(input.page);
     ayakashi
         .select("about")
         .where({itemprop: {eq: "about"}});

--- a/src/cli/scaffold/generateScraper.ts
+++ b/src/cli/scaffold/generateScraper.ts
@@ -11,7 +11,7 @@ const mkdirp = promisify(_mkdirp);
 const writeFile = promisify(_writeFile);
 const exists = promisify(_exists);
 
-export async function generateRenderlessScrapper(directory: string, name: string) {
+export async function generateScraper(directory: string, name: string) {
     const opLog = getOpLog();
     let fileName: string;
     if (name.indexOf(".js") > -1) {
@@ -19,14 +19,14 @@ export async function generateRenderlessScrapper(directory: string, name: string
     } else {
         fileName = `${name}.js`;
     }
-    const scrappersFolder = pathJoin(directory, "scrappers");
-    const filePath = pathJoin(scrappersFolder, fileName);
+    const scrapersFolder = pathJoin(directory, "scrapers");
+    const filePath = pathJoin(scrapersFolder, fileName);
     if (await exists(filePath)) {
-        opLog.error(`scrapper <${name}> already exists in ${filePath}`);
+        opLog.error(`scraper <${name}> already exists in ${filePath}`);
         return;
     }
     opLog.info(`Created <${name}> in ${filePath}`);
-    await mkdirp(scrappersFolder);
+    await mkdirp(scrapersFolder);
     const content = getContent();
     await writeFile(filePath, content);
 }
@@ -34,10 +34,10 @@ export async function generateRenderlessScrapper(directory: string, name: string
 function getContent() {
     return (
 `/**
-* @param {import("@ayakashi/types").IRenderlessAyakashiInstance} ayakashi
+* @param {import("@ayakashi/types").IAyakashiInstance} ayakashi
 */
 module.exports = async function(ayakashi, input, params) {
-    await ayakashi.load(input.page);
+    await ayakashi.goTo(input.page);
     ayakashi
         .select("about")
         .where({itemprop: {eq: "about"}});

--- a/src/engine/createConnection.ts
+++ b/src/engine/createConnection.ts
@@ -13,7 +13,7 @@ const d = debug("ayakashi:engine:connection");
 type Unsubscriber = () => void;
 
 /**
- * Emulation options for the scrapper to use.
+ * Emulation options for the scraper to use.
  */
 export type EmulatorOptions = {
     /**

--- a/src/prelude/actions/meta.ts
+++ b/src/prelude/actions/meta.ts
@@ -62,16 +62,16 @@ export function attachMetaActions(
     (<IAyakashiInstance>ayakashiInstance).pause = async function() {
         try {
             await ayakashiInstance.evaluate(function() {
-                console.warn("[Ayakashi]: scrapper execution is paused, run ayakashi.resume() in devtools to resume");
+                console.warn("[Ayakashi]: scraper execution is paused, run ayakashi.resume() in devtools to resume");
                 this.paused = true;
             });
-            opLog.warn("scrapper execution is paused, run ayakashi.resume() in devtools to resume");
+            opLog.warn("scraper execution is paused, run ayakashi.resume() in devtools to resume");
             await (<IAyakashiInstance>ayakashiInstance).waitUntil<boolean>(function() {
                 return ayakashiInstance.evaluate<boolean>(function() {
                     return this.paused === false;
                 });
             }, 100, 0);
-            opLog.warn("scrapper execution is resumed");
+            opLog.warn("scraper execution is resumed");
         } catch (e) {
             throw e;
         }

--- a/src/prelude/prelude.ts
+++ b/src/prelude/prelude.ts
@@ -170,7 +170,7 @@ ayakashi.registerExtractor("id", function() {
 */
     registerExtractor: (extractorName: string, extractorFn: ExtractorFn, dependsOn?: string[]) => void;
 /**
- * Pauses the execution of the scrapper.
+ * Pauses the execution of the scraper.
  * Learn more here: http://ayakashi.io/docs/guide/debugging.html
  * ```js
 await ayakashi.pause();
@@ -178,7 +178,7 @@ await ayakashi.pause();
 */
     pause: () => Promise<void>;
 /**
- * Yields extracted data from a scrapper to the next step of the pipeline.
+ * Yields extracted data from a scraper to the next step of the pipeline.
  * Learn more about yield in this example: http://ayakashi.io/guide/building-a-complete-scraping-project.html
  * ```js
 ayakashi.select("myDivProp").where({id: {eq: "myDiv"}});
@@ -202,12 +202,12 @@ for (const link of extractedLinks) {
 */
     yieldEach: (extracted: object[] | Promise<object[]>) => Promise<void>;
 /**
- * Recursively re-run the scrapper by yielding the extracted data to itself.
+ * Recursively re-run the scraper by yielding the extracted data to itself.
  * The data will be available in the input object.
 */
     recursiveYield: (extracted: object | Promise<object>) => Promise<void>;
 /**
- * Recursively re-run the scrapper by yielding multiple extractions individually in a single (atomic) operation.
+ * Recursively re-run the scraper by yielding multiple extractions individually in a single (atomic) operation.
  * The data will be available in the input object.
 */
     recursiveYieldEach: (extracted: object[] | Promise<object[]>) => Promise<void>;

--- a/src/prelude/renderlessPrelude.ts
+++ b/src/prelude/renderlessPrelude.ts
@@ -28,7 +28,7 @@ export interface IRenderlessAyakashiInstance {
     recursiveYieldEach: IAyakashiInstance["recursiveYieldEach"];
     page: JSDOM;
 /**
- * Fetches and loads a page in the renderlessScrapper's context.
+ * Fetches and loads a page in the renderlessScraper's context.
  * A timeout can be specified (in ms) for slow pages (default 10s).
  * Use a timeout of 0 to disable the timeout.
  * ```js

--- a/src/runner/apiScraperWrapper.ts
+++ b/src/runner/apiScraperWrapper.ts
@@ -7,7 +7,7 @@ import {apiPrelude} from "../prelude/apiPrelude";
 import {attachYields} from "../prelude/actions/yield";
 import {getOpLog} from "../opLog/opLog";
 import debug from "debug";
-const d = debug("ayakashi:apiScrapperWrapper");
+const d = debug("ayakashi:apiScraperWrapper");
 
 type PassedLog = {
     id: string,
@@ -33,10 +33,10 @@ type PassedLog = {
     }
 };
 
-export default async function apiScrapperWrapper(log: PassedLog) {
+export default async function apiScraperWrapper(log: PassedLog) {
     try {
         const opLog = getOpLog();
-        opLog.info("running apiScrapper", log.body.module);
+        opLog.info("running apiScraper", log.body.module);
 
         const ayakashiInstance = apiPrelude();
 
@@ -75,31 +75,31 @@ export default async function apiScrapperWrapper(log: PassedLog) {
         const yieldWatcher = {yieldedAtLeastOnce: false};
         attachYields(ayakashiInstance, pipeprocClient, log.body.saveTopic, log.body.selfTopic, yieldWatcher);
 
-        let scrapperModule;
+        let scraperModule;
         try {
             if (log.body.config.simple) {
-                scrapperModule = require(pathResolve(log.body.projectFolder, log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, log.body.module));
             } else {
-                scrapperModule = require(pathResolve(log.body.projectFolder, "scrappers", log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, "scrapers", log.body.module));
             }
-            if (typeof scrapperModule !== "function") {
-                scrapperModule = scrapperModule.default;
+            if (typeof scraperModule !== "function") {
+                scraperModule = scraperModule.default;
             }
-            if (typeof scrapperModule !== "function") {
-                throw new Error(`Scrapper <${log.body.module}> is not a function`);
+            if (typeof scraperModule !== "function") {
+                throw new Error(`Scraper <${log.body.module}> is not a function`);
             }
         } catch (e) {
             opLog.error(e.message);
             throw e;
         }
-        //run the scrapper
+        //run the scraper
         let result;
         try {
             //@ts-ignore
             if (log.body.input && log.body.input.continue === true) delete log.body.input.continue;
-            result = await scrapperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
+            result = await scraperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
         } catch (e) {
-            opLog.error(`There was an error while running scrapper <${log.body.module}> -`, e.message, e.stack);
+            opLog.error(`There was an error while running scraper <${log.body.module}> -`, e.message, e.stack);
             throw e;
         }
         if (result) {

--- a/src/runner/parseConfig.ts
+++ b/src/runner/parseConfig.ts
@@ -21,7 +21,7 @@ type StepConfig = {
      */
     localAutoLoad?: boolean,
     /**
-     * Emulation options for the scrapper to use.
+     * Emulation options for the scraper to use.
      */
     emulatorOptions?: EmulatorOptions,
     /**
@@ -74,12 +74,12 @@ export type Config = {
          */
         headless?: boolean,
         /**
-         * Configures the userAgent for all scrappers.
+         * Configures the userAgent for all scrapers.
          * By default a random userAgent is used.
          */
         userAgent?: "random" | "desktop" | "mobile",
         /**
-         * Sets a proxy url for all scrappers.
+         * Sets a proxy url for all scrapers.
          */
         proxyUrl?: string,
         /**
@@ -125,7 +125,7 @@ export type Config = {
         /**
          * The type of the step.
          */
-        type: "scrapper" | "renderlessScrapper" | "script",
+        type: "scraper" | "renderlessScraper" | "script",
         /**
          * The name of the module.
          */
@@ -139,7 +139,7 @@ export type Config = {
          */
         config?: StepConfig,
         /**
-         * Specify external modules that should be loaded by the scrapper.
+         * Specify external modules that should be loaded by the scraper.
          */
         load?: StepLoadingOptions,
         /**
@@ -149,7 +149,7 @@ export type Config = {
             /**
              * The type of the step.
              */
-            type: "scrapper" | "renderlessScrapper" | "apiScrapper" | "script",
+            type: "scraper" | "renderlessScraper" | "apiScraper" | "script",
             /**
              * The name of the module.
              */
@@ -163,7 +163,7 @@ export type Config = {
              */
             config?: StepConfig,
             /**
-             * Specify external modules that should be loaded by the scrapper.
+             * Specify external modules that should be loaded by the scraper.
              */
             load?: StepLoadingOptions
         }[]
@@ -175,7 +175,7 @@ export type Config = {
         /**
          * The type of the step.
          */
-        type: "scrapper" | "renderlessScrapper" | "apiScrapper"  | "script",
+        type: "scraper" | "renderlessScraper" | "apiScraper"  | "script",
         /**
          * The name of the module.
          */
@@ -189,7 +189,7 @@ export type Config = {
          */
         config?: StepConfig,
         /**
-         * Specify external modules that should be loaded by the scrapper.
+         * Specify external modules that should be loaded by the scraper.
          */
         load?: StepLoadingOptions,
         /**
@@ -199,7 +199,7 @@ export type Config = {
             /**
              * The type of the step.
              */
-            type: "scrapper" | "renderlessScrapper" | "apiScrapper"  | "script",
+            type: "scraper" | "renderlessScraper" | "apiScraper"  | "script",
             /**
              * The name of the module.
              */
@@ -213,7 +213,7 @@ export type Config = {
              */
             config?: StepConfig,
             /**
-             * Specify external modules that should be loaded by the scrapper.
+             * Specify external modules that should be loaded by the scraper.
              */
             load?: StepLoadingOptions
         }[]
@@ -345,17 +345,17 @@ export function countSteps(steps: (string | string[])[]) {
     return count;
 }
 
-export function isUsingNormalScrapper(steps: (string | string[])[], config: Config) {
+export function isUsingNormalScraper(steps: (string | string[])[], config: Config) {
     let using = false;
     for (const step of steps) {
         if (Array.isArray(step)) {
             for (const st of step) {
-                if (getObjectReference(config, st).type === "scrapper") {
+                if (getObjectReference(config, st).type === "scraper") {
                     using = true;
                 }
             }
         } else {
-            if (getObjectReference(config, step).type === "scrapper") {
+            if (getObjectReference(config, step).type === "scraper") {
                 using = true;
             }
         }
@@ -528,31 +528,31 @@ function addStep(
     if (step.match("init")) return;
     if (!procGenerators.find(pr => pr.from === `pre_${step}` && pr.to === step)) {
         const objectRef = getObjectReference(config, step);
-        if (objectRef.type === "scrapper") {
+        if (objectRef.type === "scraper") {
             if (!objectRef.module) return;
             procGenerators.push({
                 name: `proc_from_pre_${step}_to_${step}`,
                 from: `pre_${step}`,
                 to: step,
-                processor: pathResolve(appRoot, "lib/runner/scrapperWrapper.js"),
+                processor: pathResolve(appRoot, "lib/runner/scraperWrapper.js"),
                 config: objectRef.config || {}
             });
-        } else if (objectRef.type === "renderlessScrapper") {
+        } else if (objectRef.type === "renderlessScraper") {
             if (!objectRef.module) return;
             procGenerators.push({
                 name: `proc_from_pre_${step}_to_${step}`,
                 from: `pre_${step}`,
                 to: step,
-                processor: pathResolve(appRoot, "lib/runner/renderlessScrapperWrapper.js"),
+                processor: pathResolve(appRoot, "lib/runner/renderlessScraperWrapper.js"),
                 config: objectRef.config || {}
             });
-        } else if (objectRef.type === "apiScrapper") {
+        } else if (objectRef.type === "apiScraper") {
             if (!objectRef.module) return;
             procGenerators.push({
                 name: `proc_from_pre_${step}_to_${step}`,
                 from: `pre_${step}`,
                 to: step,
-                processor: pathResolve(appRoot, "lib/runner/apiScrapperWrapper.js"),
+                processor: pathResolve(appRoot, "lib/runner/apiScraperWrapper.js"),
                 config: objectRef.config || {}
             });
         }  else {
@@ -596,7 +596,7 @@ function addPreStep(
                 //tslint:disable max-line-length
                 processor: new Function("log", `
                     const obj = ${JSON.stringify(getObjectReference(config, step))};
-                    if (obj.type === "scrapper") {
+                    if (obj.type === "scraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},
@@ -614,7 +614,7 @@ function addPreStep(
                             selfTopic: "${previousStep}",
                             appRoot: "${appRoot}"
                         });
-                    } else if (obj.type === "renderlessScrapper") {
+                    } else if (obj.type === "renderlessScraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},
@@ -634,7 +634,7 @@ function addPreStep(
                             proxyUrl: "${(config.config && config.config.proxyUrl) || ""}",
                             ignoreCertificateErrors: ${(config.config && config.config.ignoreCertificateErrors) || false}
                         });
-                    } else if (obj.type === "apiScrapper") {
+                    } else if (obj.type === "apiScraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},
@@ -701,7 +701,7 @@ function addParallelPreStep(
                     //tslint:disable max-line-length
                     processor: new Function("log", `
                         const obj = ${JSON.stringify(getObjectReference(config, step))};
-                        if (obj.type === "scrapper") {
+                        if (obj.type === "scraper") {
                             return Promise.resolve({
                                 input: log.body,
                                 config: (obj && obj.config) || {},
@@ -719,7 +719,7 @@ function addParallelPreStep(
                                 selfTopic: "${ppst}",
                                 appRoot: "${appRoot}"
                             });
-                        } else if (obj.type === "renderlessScrapper") {
+                        } else if (obj.type === "renderlessScraper") {
                             return Promise.resolve({
                                 input: log.body,
                                 config: (obj && obj.config) || {},
@@ -739,7 +739,7 @@ function addParallelPreStep(
                                 proxyUrl: "${(config.config && config.config.proxyUrl) || ""}",
                                 ignoreCertificateErrors: ${(config.config && config.config.ignoreCertificateErrors) || false}
                             });
-                        } else if (obj.type === "apiScrapper") {
+                        } else if (obj.type === "apiScraper") {
                             return Promise.resolve({
                                 input: log.body,
                                 config: (obj && obj.config) || {},
@@ -788,7 +788,7 @@ function addParallelPreStep(
                 //tslint:disable max-line-length
                 processor: new Function("log", `
                     const obj = ${JSON.stringify(getObjectReference(config, step))};
-                    if (obj.type === "scrapper") {
+                    if (obj.type === "scraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},
@@ -805,7 +805,7 @@ function addParallelPreStep(
                             selfTopic: "${previousPreviousStep}",
                             appRoot: "${appRoot}"
                         });
-                    } else if (obj.type === "renderlessScrapper") {
+                    } else if (obj.type === "renderlessScraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},
@@ -824,7 +824,7 @@ function addParallelPreStep(
                             proxyUrl: "${(config.config && config.config.proxyUrl) || ""}",
                             ignoreCertificateErrors: ${(config.config && config.config.ignoreCertificateErrors) || false}
                         });
-                    } else if (obj.type === "apiScrapper") {
+                    } else if (obj.type === "apiScraper") {
                         return Promise.resolve({
                             input: log.body,
                             config: (obj && obj.config) || {},

--- a/src/runner/parseConfig.ts
+++ b/src/runner/parseConfig.ts
@@ -363,6 +363,26 @@ export function isUsingNormalScraper(steps: (string | string[])[], config: Confi
     return using;
 }
 
+export function hasTypo(steps: (string | string[])[], config: Config) {
+    let typo = false;
+    for (const step of steps) {
+        if (Array.isArray(step)) {
+            for (const st of step) {
+                const type = getObjectReference(config, st).type;
+                if (type === "scrapper" || type === "apiScrapper" || type === "renderlessScrapper") {
+                    typo = true;
+                }
+            }
+        } else {
+            const type = getObjectReference(config, step).type;
+            if (type === "scrapper" || type === "apiScrapper" || type === "renderlessScrapper") {
+                typo = true;
+            }
+        }
+    }
+    return typo;
+}
+
 export function getObjectReference(
     config: Config,
     stepName: string

--- a/src/runner/renderlessScraperWrapper.ts
+++ b/src/runner/renderlessScraperWrapper.ts
@@ -13,7 +13,7 @@ import {renderlessPrelude} from "../prelude/renderlessPrelude";
 import {attachYields} from "../prelude/actions/yield";
 import {getOpLog} from "../opLog/opLog";
 import debug from "debug";
-const d = debug("ayakashi:renderlessScrapperWrapper");
+const d = debug("ayakashi:renderlessScraperWrapper");
 
 type PassedLog = {
     id: string,
@@ -51,10 +51,10 @@ type PassedLog = {
     }
 };
 
-export default async function renderlessScrapperWrapper(log: PassedLog) {
+export default async function renderlessScraperWrapper(log: PassedLog) {
     try {
         const opLog = getOpLog();
-        opLog.info("running renderlessScrapper", log.body.module);
+        opLog.info("running renderlessScraper", log.body.module);
 
         const ayakashiInstance = await renderlessPrelude();
 
@@ -103,32 +103,32 @@ export default async function renderlessScrapperWrapper(log: PassedLog) {
         loadExternalExtractors(ayakashiInstance, log.body.load.extractors);
         loadLocalExtractors(ayakashiInstance, log.body.projectFolder);
 
-        let scrapperModule;
+        let scraperModule;
         try {
             if (log.body.config.simple) {
-                scrapperModule = require(pathResolve(log.body.projectFolder, log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, log.body.module));
             } else {
-                scrapperModule = require(pathResolve(log.body.projectFolder, "scrappers", log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, "scrapers", log.body.module));
             }
-            if (typeof scrapperModule !== "function") {
-                scrapperModule = scrapperModule.default;
+            if (typeof scraperModule !== "function") {
+                scraperModule = scraperModule.default;
             }
-            if (typeof scrapperModule !== "function") {
-                throw new Error(`Scrapper <${log.body.module}> is not a function`);
+            if (typeof scraperModule !== "function") {
+                throw new Error(`Scraper <${log.body.module}> is not a function`);
             }
         } catch (e) {
             opLog.error(e.message);
             await ayakashiInstance.__connection.release();
             throw e;
         }
-        //run the scrapper
+        //run the scraper
         let result;
         try {
             //@ts-ignore
             if (log.body.input && log.body.input.continue === true) delete log.body.input.continue;
-            result = await scrapperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
+            result = await scraperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
         } catch (e) {
-            opLog.error(`There was an error while running scrapper <${log.body.module}> -`, e.message, e.stack);
+            opLog.error(`There was an error while running scraper <${log.body.module}> -`, e.message, e.stack);
             await ayakashiInstance.__connection.release();
             throw e;
         }

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -16,7 +16,7 @@ import {
     validateStepFormat,
     createProcGenerators,
     countSteps,
-    isUsingNormalScrapper
+    isUsingNormalScraper
 } from "./parseConfig";
 
 import {downloadChromium} from "../chromeDownloader/downloader";
@@ -26,13 +26,13 @@ import {getOrCreateStoreProjectFolder, hasPreviousRun, clearPreviousRun, getPipe
 import debug from "debug";
 const d = debug("ayakashi:runner");
 
-export async function run(projectFolder: string, config: Config, resume: boolean, simpleScrapper?: string) {
+export async function run(projectFolder: string, config: Config, resume: boolean, simpleScraper?: string) {
     const opLog = getOpLog();
     let steps: (string | string[])[];
     let procGenerators: ProcGenerator[];
     let initializers: string[];
     const storeProjectFolder =
-        await getOrCreateStoreProjectFolder(simpleScrapper ? `${projectFolder}/${simpleScrapper}` : projectFolder);
+        await getOrCreateStoreProjectFolder(simpleScraper ? `${projectFolder}/${simpleScraper}` : projectFolder);
     try {
         steps = firstPass(config);
         checkStepLevels(steps);
@@ -66,11 +66,11 @@ export async function run(projectFolder: string, config: Config, resume: boolean
     let headlessChrome = null;
     try {
         //launch chrome
-        if (isUsingNormalScrapper(steps, config)) {
-            d("using normal scrapper(s), chrome will be spawned");
+        if (isUsingNormalScraper(steps, config)) {
+            d("using normal scraper(s), chrome will be spawned");
             headlessChrome = await launch(config, storeProjectFolder, chromePath);
         } else {
-            d("using renderless scrapper(s) only, chrome will not be spawned");
+            d("using renderless scraper(s) only, chrome will not be spawned");
         }
 
         //finalize systemProcs

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -45,7 +45,6 @@ export async function run(projectFolder: string, config: Config, resume: boolean
             opLog.error("Please use scraper/renderlessScraper/apiScraper (with a single 'p') instead.");
             throw new Error("Deprecated configuration option");
         }
-        console.log(projectFolder);
         if (!simpleScraper && existsSync(pathResolve(projectFolder, "scrappers")) &&
             !existsSync(pathResolve(projectFolder, "scrapers"))) {
                 opLog.error("This project still uses a 'scrappers' folder.");

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -7,6 +7,7 @@ import dayjs from "dayjs";
 import UserAgent from "user-agents";
 import {getOpLog} from "../opLog/opLog";
 import {cpus} from "os";
+import {existsSync} from "fs";
 
 import {
     Config,
@@ -16,7 +17,8 @@ import {
     validateStepFormat,
     createProcGenerators,
     countSteps,
-    isUsingNormalScraper
+    isUsingNormalScraper,
+    hasTypo
 } from "./parseConfig";
 
 import {downloadChromium} from "../chromeDownloader/downloader";
@@ -37,6 +39,20 @@ export async function run(projectFolder: string, config: Config, resume: boolean
         steps = firstPass(config);
         checkStepLevels(steps);
         validateStepFormat(steps);
+        if (hasTypo(steps, config)) {
+            opLog.error("The configuration still uses one of scrapper/renderlessScrapper/apiScrapper.");
+            opLog.error("This was a typo and has been deprecated.");
+            opLog.error("Please use scraper/renderlessScraper/apiScraper (with a single 'p') instead.");
+            throw new Error("Deprecated configuration option");
+        }
+        console.log(projectFolder);
+        if (!simpleScraper && existsSync(pathResolve(projectFolder, "scrappers")) &&
+            !existsSync(pathResolve(projectFolder, "scrapers"))) {
+                opLog.error("This project still uses a 'scrappers' folder.");
+                opLog.error("This was a typo and has been deprecated.");
+                opLog.error("Please move all your scraper files to a 'scrapers' folder (with a single 'p').");
+                throw new Error("Deprecated folder structure");
+        }
         const parsedConfig = createProcGenerators(config, steps, {
             bridgePort: (config.config && config.config.bridgePort) || 9731,
             protocolPort: (config.config && config.config.protocolPort) || 9730,
@@ -49,7 +65,6 @@ export async function run(projectFolder: string, config: Config, resume: boolean
         procGenerators = parsedConfig.procGenerators;
         initializers = parsedConfig.initializers;
     } catch (e) {
-        opLog.error("Config Error -", e.message);
         throw e;
     }
 

--- a/src/runner/scraperWrapper.ts
+++ b/src/runner/scraperWrapper.ts
@@ -17,7 +17,7 @@ import {
     loadExternalPreloaders
 } from "./loaders";
 import debug from "debug";
-const d = debug("ayakashi:scrapperWrapper");
+const d = debug("ayakashi:scraperWrapper");
 
 type PassedLog = {
     id: string,
@@ -57,10 +57,10 @@ type PassedLog = {
     }
 };
 
-export default async function scrapperWrapper(log: PassedLog) {
+export default async function scraperWrapper(log: PassedLog) {
     try {
         const opLog = getOpLog();
-        opLog.info("running scrapper", log.body.module);
+        opLog.info("running scraper", log.body.module);
         //get a tab and create a connection
         let tab;
         try {
@@ -94,13 +94,13 @@ export default async function scrapperWrapper(log: PassedLog) {
         if (log.body.config.pipeConsole !== false) {
             connection.pipe.console(function(text) {
                 if (text && text.indexOf("[Ayakashi]") === -1) {
-                    opLog.debug(`<Scrapper:${log.body.module}:Browser>`, text);
+                    opLog.debug(`<Scraper:${log.body.module}:Browser>`, text);
                 }
             });
         }
         if (log.body.config.pipeExceptions !== false) {
             connection.pipe.uncaughtException(function(exception) {
-                opLog.debug(`<Scrapper:${log.body.module}:Browser:Exception>`, JSON.stringify(exception, null, 2));
+                opLog.debug(`<Scraper:${log.body.module}:Browser:Exception>`, JSON.stringify(exception, null, 2));
             });
         }
         const ayakashiInstance = await prelude(connection);
@@ -155,34 +155,34 @@ export default async function scrapperWrapper(log: PassedLog) {
             await loadLocals(connection, ayakashiInstance, log);
         }
 
-        //activate the connection and load the scrapper
+        //activate the connection and load the scraper
         await connection.activate();
-        let scrapperModule;
+        let scraperModule;
         try {
             if (log.body.config.simple) {
-                scrapperModule = require(pathResolve(log.body.projectFolder, log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, log.body.module));
             } else {
-                scrapperModule = require(pathResolve(log.body.projectFolder, "scrappers", log.body.module));
+                scraperModule = require(pathResolve(log.body.projectFolder, "scrapers", log.body.module));
             }
-            if (typeof scrapperModule !== "function") {
-                scrapperModule = scrapperModule.default;
+            if (typeof scraperModule !== "function") {
+                scraperModule = scraperModule.default;
             }
-            if (typeof scrapperModule !== "function") {
-                throw new Error(`Scrapper <${log.body.module}> is not a function`);
+            if (typeof scraperModule !== "function") {
+                throw new Error(`Scraper <${log.body.module}> is not a function`);
             }
         } catch (e) {
             opLog.error(e.message);
             await connection.release();
             throw e;
         }
-        //run the scrapper
+        //run the scraper
         let result;
         try {
             //@ts-ignore
             if (log.body.input && log.body.input.continue === true) delete log.body.input.continue;
-            result = await scrapperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
+            result = await scraperModule(ayakashiInstance, log.body.input || {}, log.body.params || {});
         } catch (e) {
-            opLog.error(`There was an error while running scrapper <${log.body.module}> -`, e.message, e.stack);
+            opLog.error(`There was an error while running scraper <${log.body.module}> -`, e.message, e.stack);
             await connection.release();
             throw e;
         }

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -5,9 +5,9 @@ import {getStoreDir} from "./store";
 import {exists} from "fs";
 import rimraf from "rimraf";
 
-export async function getOrCreateStoreProjectFolder(projectFolderOrScrapperName: string): Promise<string> {
+export async function getOrCreateStoreProjectFolder(projectFolderOrScraperName: string): Promise<string> {
     const storeDir = await getStoreDir();
-    const folderName = createHash("md5").update(projectFolderOrScrapperName).digest("hex");
+    const folderName = createHash("md5").update(projectFolderOrScraperName).digest("hex");
     const fullFolder = pathResolve(storeDir, "projects", folderName);
     return new Promise(function(resolve, reject) {
         mkdirp(fullFolder, function(err) {
@@ -20,22 +20,22 @@ export async function getOrCreateStoreProjectFolder(projectFolderOrScrapperName:
     });
 }
 
-export function hasPreviousRun(projectFolderOrScrapperName: string): Promise<boolean> {
+export function hasPreviousRun(projectFolderOrScraperName: string): Promise<boolean> {
     return new Promise(function(resolve) {
-        exists(getPipeprocFolder(projectFolderOrScrapperName), function(ex) {
+        exists(getPipeprocFolder(projectFolderOrScraperName), function(ex) {
             resolve(ex);
         });
     });
 }
 
-export function clearPreviousRun(projectFolderOrScrapperName: string): Promise<boolean> {
+export function clearPreviousRun(projectFolderOrScraperName: string): Promise<boolean> {
     return new Promise(function(resolve) {
-        rimraf(getPipeprocFolder(projectFolderOrScrapperName), function(_err) {
+        rimraf(getPipeprocFolder(projectFolderOrScraperName), function(_err) {
             resolve();
         });
     });
 }
 
-export function getPipeprocFolder(projectFolderOrScrapperName: string): string {
-    return pathJoin(projectFolderOrScrapperName, "pipeproc");
+export function getPipeprocFolder(projectFolderOrScraperName: string): string {
+    return pathJoin(projectFolderOrScraperName, "pipeproc");
 }

--- a/tslint.json
+++ b/tslint.json
@@ -57,7 +57,7 @@
         "curly": false,
         "ordered-imports": false,
         "align": false,
-        "cyclomatic-complexity": [true, 22],
+        "cyclomatic-complexity": false,
         "mocha-no-side-effect-code": false,
         "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
         "max-func-body-length": false,


### PR DESCRIPTION
There is a typo across the whole codebase where `scraper` is written as `scrapper`.
This PR fixes the typo and also adds 2 deprecation errors for projects that still use the incorrect version in their configuration files or folder structure.

The docs will also be updated to reflect the change.