### PR TITLE
use Chrome for Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['14', '16', '18']
+        node_version: ['16', '18']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -3,7 +3,7 @@ import prompts from "prompts";
 import {run} from "../runner/runner";
 import {getOpLog} from "../opLog/opLog";
 import {downloadChromium, getRecommendedChromiumRevision} from "../chromeDownloader/downloader";
-import {isChromiumAlreadyInstalled, getStoredRevision} from "../store/chromium";
+import {isChromiumAlreadyInstalled, getStoredRevision, isCfT} from "../store/chromium";
 import {Config} from "../runner/parseConfig";
 import {getDirectory} from "./getDirectory";
 import {prepareStandard} from "./prepareStandard";
@@ -346,7 +346,7 @@ yargs
         await refreshUA();
     })
     //@ts-ignore
-    .command("update-stealth", "Updates the headless chromium stealth patches", (_argv) => {
+    .command("update-stealth", "Updates the headless chrome stealth patches", (_argv) => {
         yargs
         .epilogue("Learn more at https://ayakashi-io.github.io/docs/installation#updating-subcomponents");
         //@ts-ignore
@@ -360,10 +360,10 @@ yargs
         const opLog = getOpLog();
         const storedRevision = await getStoredRevision();
         opLog.info(`Ayakashi version: ${packageJson.version}`);
-        if (await isChromiumAlreadyInstalled()) {
-            opLog.info(`Chromium revision: ${storedRevision}`);
+        if (await isChromiumAlreadyInstalled() && await isCfT()) {
+            opLog.info(`Chrome revision: ${storedRevision}`);
         } else {
-            opLog.info(`Chromium revision: none`);
+            opLog.info(`Chrome revision: none`);
         }
     })
     .demandCommand().recommendCommands().strict()

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -283,30 +283,59 @@ yargs
         }
     })
     //@ts-ignore
-    .command("update-chrome", "Downloads the recommended, latest or specified chromium revision", (_argv) => {
+    .command("update-chrome", "Downloads the recommended, latest or specified chrome revision", (_argv) => {
         yargs
         .option("revision", {
-            describe: "Download a specific revision",
-            type: "number",
+            describe: "Download a specific revision. Format: '114.0.5735.133'",
+            type: "string",
             alias: "r"
         })
-        .option("latest", {
-            describe: "Download the latest revision",
+        .option("stable", {
+            describe: "Download the latest stable revision",
+            type: "boolean"
+        })
+        .option("beta", {
+            describe: "Download the latest beta revision",
+            type: "boolean"
+        })
+        .option("dev", {
+            describe: "Download the latest dev revision",
+            type: "boolean"
+        })
+        .option("canary", {
+            describe: "Download the latest canary revision",
             type: "boolean"
         })
         .epilogue("Learn more at https://ayakashi-io.github.io/docs/reference/cli-commands.html#update-chrome");
         //@ts-ignore
     }, async function(argv) {
         const storedRevision = await getStoredRevision();
-        let revision = 0;
+        const options: {
+            useExact: boolean,
+            revision: string,
+            useChannel: boolean,
+            channel: "Stable" | "Beta" | "Dev" | "Canary" | ""
+        } = {useExact: false, revision: "", useChannel: false, channel: ""};
         if (argv.revision) {
-            revision = <number>argv.revision;
-        } else if (argv.latest) {
-            revision = 0;
+            options.revision = <string>argv.revision;
+            options.useExact = true;
+        } else if (argv.stable) {
+            options.channel = "Stable";
+            options.useChannel = true;
+        } else if (argv.beta) {
+            options.channel = "Beta";
+            options.useChannel = true;
+        } else if (argv.dev) {
+            options.channel = "Dev";
+            options.useChannel = true;
+        } else if (argv.canary) {
+            options.channel = "Canary";
+            options.useChannel = true;
         } else {
-            revision = await getRecommendedChromiumRevision();
+            options.revision = await getRecommendedChromiumRevision();
+            options.useExact = true;
         }
-        await downloadChromium(revision, storedRevision);
+        await downloadChromium(options, storedRevision);
     })
     //@ts-ignore
     .command("update-ua", "Updates the builtin database of user agent strings", (_argv) => {

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -24,7 +24,7 @@ import {
 } from "./parseConfig";
 
 import {downloadChromium, getRecommendedChromiumRevision} from "../chromeDownloader/downloader";
-import {isChromiumAlreadyInstalled, getChromePath} from "../store/chromium";
+import {isChromiumAlreadyInstalled, getChromePath, isCfT} from "../store/chromium";
 import {
     getOrCreateStoreProjectFolder,
     hasPreviousRun,
@@ -145,7 +145,7 @@ export async function run(projectFolder: string, config: Config, options: {
     if (config.config && config.config.chromePath) {
         chromePath = config.config.chromePath;
     } else {
-        if (!(await isChromiumAlreadyInstalled())) {
+        if (!(await isChromiumAlreadyInstalled()) || !(await isCfT())) {
             await downloadChromium({
                 useExact: true,
                 revision: await getRecommendedChromiumRevision(),

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -146,7 +146,12 @@ export async function run(projectFolder: string, config: Config, options: {
         chromePath = config.config.chromePath;
     } else {
         if (!(await isChromiumAlreadyInstalled())) {
-            await downloadChromium(await getRecommendedChromiumRevision(), 0);
+            await downloadChromium({
+                useExact: true,
+                revision: await getRecommendedChromiumRevision(),
+                useChannel: false,
+                channel: ""
+            }, "");
         }
         chromePath = await getChromePath();
     }

--- a/src/store/chromium.ts
+++ b/src/store/chromium.ts
@@ -6,6 +6,9 @@ import {getStoreDir} from "./store";
 export async function getStoredRevision() {
     const storeDir = await getStoreDir();
     try {
+        if (!(await isCfT())) {
+            return "";
+        }
         return readFileSync(pathResolve(storeDir, "chromium", "revision"), "utf8");
     } catch (_e) {
         return "";
@@ -44,6 +47,20 @@ export async function isChromiumAlreadyInstalled() {
     const storeDir = await getStoreDir();
     try {
         if (lstatSync(`${storeDir}/chromium`).isDirectory()) {
+            return true;
+        } else {
+            return false;
+        }
+    } catch (e) {
+        return false;
+    }
+}
+
+export async function isCfT() {
+    const storeDir = await getStoreDir();
+    try {
+        const revision = readFileSync(pathResolve(storeDir, "chromium", "revision"), "utf8");
+        if (revision && revision.match(/\d+[.]\d+[.]\d+[.]\d+/)) {
             return true;
         } else {
             return false;

--- a/src/store/chromium.ts
+++ b/src/store/chromium.ts
@@ -6,16 +6,15 @@ import {getStoreDir} from "./store";
 export async function getStoredRevision() {
     const storeDir = await getStoreDir();
     try {
-        const revision = readFileSync(pathResolve(storeDir, "chromium", "revision"), "utf8");
-        return parseInt(revision, 10);
+        return readFileSync(pathResolve(storeDir, "chromium", "revision"), "utf8");
     } catch (_e) {
-        return 0;
+        return "";
     }
 }
 
-export async function updateStoredRevision(newRevision: number) {
+export async function updateStoredRevision(newRevision: string) {
     const storeDir = await getStoreDir();
-    writeFileSync(pathResolve(storeDir, "chromium", "revision"), String(newRevision));
+    writeFileSync(pathResolve(storeDir, "chromium", "revision"), newRevision);
 }
 
 export async function getChromePath() {
@@ -23,13 +22,17 @@ export async function getChromePath() {
     let subfolder = "";
     if (process.platform === "linux") {
         executable = "chrome";
-        subfolder = "chrome-linux";
+        subfolder = "chrome-linux64";
     } else if (process.platform === "darwin") {
-        executable = "Chromium.app/Contents/MacOS/Chromium";
-        subfolder = "chrome-mac";
+        executable = "Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing";
+        subfolder = "chrome-mac-x64";
     } else if (process.platform === "win32") {
         executable = "chrome.exe";
-        subfolder = "chrome-win";
+        if (process.arch === "x64") {
+            subfolder = "chrome-win64";
+        } else {
+            subfolder = "chrome-win32";
+        }
     } else {
         throw new Error("invalid_platform");
     }


### PR DESCRIPTION
Replaces Chromium with the new "Chrome for Testing" distribution.
https://developer.chrome.com/blog/chrome-for-testing/
https://github.com/GoogleChromeLabs/chrome-for-testing

The default download will use whatever version puppeteer is currently using (taken from here https://raw.githubusercontent.com/puppeteer/puppeteer/main/packages/puppeteer-core/src/revisions.ts)

Also adds a new set of flags to download the latest version from each chrome channel
* `--stable`
* `--beta`
* `--dev`
* `--canary`

The `--revision` flag is still available to download specific versions.